### PR TITLE
15/11/2022 - Sections 11 to 14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,17 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- FlyWay -->
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
+
         <!-- MapStruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
+            <artifactId>spring-boot-starter-hateoas</artifactId>
         </dependency>
 
         <dependency>
@@ -68,6 +66,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
         <!-- MYSQL -->
         <dependency>
             <groupId>mysql</groupId>
@@ -91,6 +95,12 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>1.5.3.Final</version>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
 
     </dependencies>

--- a/src/main/java/br/dev/paulovieira/restfulapispring/config/WebConfig.java
+++ b/src/main/java/br/dev/paulovieira/restfulapispring/config/WebConfig.java
@@ -1,0 +1,21 @@
+package br.dev.paulovieira.restfulapispring.config;
+
+import org.springframework.context.annotation.*;
+import org.springframework.http.*;
+import org.springframework.web.servlet.config.annotation.*;
+
+@Configuration
+@Profile("dev")
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        configurer
+                .favorParameter(false)
+                .ignoreAcceptHeader(false)
+                .useRegisteredExtensionsOnly(false)
+                .defaultContentType(MediaType.APPLICATION_JSON)
+                    .mediaType("json", MediaType.APPLICATION_JSON)
+                    .mediaType("json", MediaType.APPLICATION_XML);
+    }
+}

--- a/src/main/java/br/dev/paulovieira/restfulapispring/controller/PersonController.java
+++ b/src/main/java/br/dev/paulovieira/restfulapispring/controller/PersonController.java
@@ -1,9 +1,7 @@
 package br.dev.paulovieira.restfulapispring.controller;
 
 import br.dev.paulovieira.restfulapispring.dto.*;
-import br.dev.paulovieira.restfulapispring.model.*;
 import br.dev.paulovieira.restfulapispring.service.impl.*;
-import br.dev.paulovieira.restfulapispring.util.impl.*;
 import org.springframework.data.domain.*;
 import org.springframework.data.web.*;
 import org.springframework.http.*;
@@ -12,56 +10,47 @@ import org.springframework.web.bind.annotation.*;
 import java.net.*;
 
 @RestController
-@RequestMapping("/api/v1/persons")
+@RequestMapping("/api/v1/people")
 public class PersonController {
 
     private final PersonServiceImpl personService;
-    private final PersonMapperImpl mapper;
 
-    public PersonController(PersonServiceImpl personService, PersonMapperImpl mapper) {
+    public PersonController(PersonServiceImpl personService) {
         this.personService = personService;
-        this.mapper = mapper;
     }
 
-        @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/{id}", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     public ResponseEntity<Object> findById(@PathVariable("id") Long id) {
-        return ResponseEntity.ok(mapper.personToDto(personService.findById(id)));
+        return ResponseEntity.ok(personService.findById(id));
     }
 
-    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     public ResponseEntity<Page<PersonDto>> findAll(@PageableDefault(sort = "id",
             direction = Sort.Direction.ASC) Pageable pageable) {
 
-        return ResponseEntity.ok(personService.findAll(pageable)
-                .map(mapper::personToDto));
+        return ResponseEntity.ok(personService.findAll(pageable));
     }
 
-    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE},
+            produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     public ResponseEntity<PersonDto> save(@RequestBody PersonDto personDto) throws URISyntaxException {
-        var uri = new URI("/api/v1/persons/" + personDto.id());
-        return ResponseEntity.created(uri).body(mapper.personToDto(personService.save(personDto)));
+        var uri = new URI("/api/v1/people/" + personDto.getId());
+        return ResponseEntity.created(uri).body(personService.save(personDto));
     }
 
     @PutMapping(value = "/{id}",
-            consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+            consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE},
+            produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     public ResponseEntity<PersonDto> update(@PathVariable Long id, @RequestBody PersonDto personDto) {
-        var person = getPersonToUpdate(id, personDto);
-        return ResponseEntity.ok().body(mapper.personToDto(personService.save(mapper.personToDto(person))));
+        personDto.setId(id);
+        return ResponseEntity.ok().body(personService.update(personDto));
     }
 
-    @DeleteMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(value = "/{id}",
+            produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         personService.deleteById(id);
         return ResponseEntity.noContent().build();
     }
-
-    private Person getPersonToUpdate(Long id, PersonDto personDto) {
-        var person = personService.findById(id);
-        person.setFirstName(personDto.firstName());
-        person.setLastName(personDto.lastName());
-        person.setAddress(personDto.address());
-        person.setGender(personDto.gender());
-        return person;
-    }
-
 }

--- a/src/main/java/br/dev/paulovieira/restfulapispring/dto/PersonDto.java
+++ b/src/main/java/br/dev/paulovieira/restfulapispring/dto/PersonDto.java
@@ -1,10 +1,75 @@
 package br.dev.paulovieira.restfulapispring.dto;
 
+import org.springframework.hateoas.*;
+
 import java.io.*;
+import java.util.*;
 
 /**
  * A DTO for the {@link br.dev.paulovieira.restfulapispring.model.Person} entity
  */
-public record PersonDto(Long id, String firstName, String lastName, String address, String gender)
-        implements Serializable {
+public class PersonDto extends RepresentationModel<PersonDto> implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String address;
+    private String gender;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        PersonDto personDto = (PersonDto) o;
+        return getId().equals(personDto.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getId());
+    }
 }

--- a/src/main/java/br/dev/paulovieira/restfulapispring/dto/factory/PersonDtoFactory.java
+++ b/src/main/java/br/dev/paulovieira/restfulapispring/dto/factory/PersonDtoFactory.java
@@ -1,0 +1,17 @@
+package br.dev.paulovieira.restfulapispring.dto.factory;
+
+import br.dev.paulovieira.restfulapispring.dto.*;
+
+public interface PersonDtoFactory {
+
+    static PersonDto create(Long id, String firstName, String lastName, String address, String gender) {
+        var personDto = new PersonDto();
+        personDto.setId(id);
+        personDto.setFirstName(firstName);
+        personDto.setLastName(lastName);
+        personDto.setAddress(address);
+        personDto.setGender(gender);
+
+        return personDto;
+    }
+}

--- a/src/main/java/br/dev/paulovieira/restfulapispring/exception/RequiredObjectIsNullException.java
+++ b/src/main/java/br/dev/paulovieira/restfulapispring/exception/RequiredObjectIsNullException.java
@@ -1,0 +1,8 @@
+package br.dev.paulovieira.restfulapispring.exception;
+
+public class RequiredObjectIsNullException extends RuntimeException {
+
+    public RequiredObjectIsNullException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/dev/paulovieira/restfulapispring/exception/handler/CustomizedResponseEntityExceptionHandler.java
+++ b/src/main/java/br/dev/paulovieira/restfulapispring/exception/handler/CustomizedResponseEntityExceptionHandler.java
@@ -32,4 +32,14 @@ public class CustomizedResponseEntityExceptionHandler extends ResponseEntityExce
         return new ResponseEntity<>(exceptionResponse, HttpStatus.NOT_FOUND);
     }
 
+    @ExceptionHandler(RequiredObjectIsNullException.class)
+    public final ResponseEntity<ExceptionResponse> handleRequiredObjectIsNullExceptions(Exception ex, WebRequest request) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(
+                Instant.now(Clock.systemUTC()),
+                ex.getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
 }

--- a/src/main/java/br/dev/paulovieira/restfulapispring/service/PersonService.java
+++ b/src/main/java/br/dev/paulovieira/restfulapispring/service/PersonService.java
@@ -1,14 +1,13 @@
 package br.dev.paulovieira.restfulapispring.service;
 
 import br.dev.paulovieira.restfulapispring.dto.*;
-import br.dev.paulovieira.restfulapispring.model.*;
 import org.springframework.data.domain.*;
 
 public interface PersonService {
 
-    Person findById(Long id);
-    Page<Person> findAll(Pageable pageable);
-    Person save(PersonDto personDto);
-    Person update(PersonDto personDto);
+    PersonDto findById(Long id);
+    Page<PersonDto> findAll(Pageable pageable);
+    PersonDto save(PersonDto personDto);
+    PersonDto update(PersonDto personDto);
     void deleteById(Long id);
 }

--- a/src/main/java/br/dev/paulovieira/restfulapispring/util/impl/PersonMapperImpl.java
+++ b/src/main/java/br/dev/paulovieira/restfulapispring/util/impl/PersonMapperImpl.java
@@ -1,6 +1,7 @@
 package br.dev.paulovieira.restfulapispring.util.impl;
 
 import br.dev.paulovieira.restfulapispring.dto.*;
+import br.dev.paulovieira.restfulapispring.dto.factory.*;
 import br.dev.paulovieira.restfulapispring.model.*;
 import br.dev.paulovieira.restfulapispring.model.factory.*;
 import br.dev.paulovieira.restfulapispring.util.*;
@@ -11,8 +12,7 @@ public class PersonMapperImpl implements PersonMapper {
 
     @Override
     public PersonDto personToDto(Person person) {
-
-        return new PersonDto(
+        return PersonDtoFactory.create(
                 person.getId(),
                 person.getFirstName(),
                 person.getLastName(),
@@ -30,11 +30,11 @@ public class PersonMapperImpl implements PersonMapper {
     public Person dtoToPerson(PersonDto personDto) {
 
         return PersonFactory.create(
-                personDto.id(),
-                personDto.firstName(),
-                personDto.lastName(),
-                personDto.address(),
-                personDto.gender()
+                personDto.getId(),
+                personDto.getFirstName(),
+                personDto.getLastName(),
+                personDto.getAddress(),
+                personDto.getGender()
         );
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
   # JPA CONFIGURATION
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/db/migration/V1__create_table_person.sql
+++ b/src/main/resources/db/migration/V1__create_table_person.sql
@@ -1,0 +1,13 @@
+create table person
+(
+    id         bigint auto_increment
+        primary key,
+    first_name varchar(30)  not null,
+    last_name  varchar(30)  not null,
+    address    varchar(100) not null,
+    gender     varchar(6)   not null
+);
+
+create index idx_person_id
+    on person (id);
+

--- a/src/main/resources/db/migration/V2__populate_table_person.sql
+++ b/src/main/resources/db/migration/V2__populate_table_person.sql
@@ -1,0 +1,5 @@
+insert into person (id, first_name, last_name, address, gender)values
+(1, 'John', 'Marston', 'Valentine', 'Male'),
+(2, 'Arthur', 'Morgan', 'Saint Denis', 'Male'),
+(3, 'Dutch', 'Van der Linde', 'West Elizabeth', 'Male');
+

--- a/src/test/java/br/dev/paulovieira/restfulapispring/controller/PersonControllerTest.java
+++ b/src/test/java/br/dev/paulovieira/restfulapispring/controller/PersonControllerTest.java
@@ -1,6 +1,7 @@
 package br.dev.paulovieira.restfulapispring.controller;
 
 import br.dev.paulovieira.restfulapispring.dto.*;
+import br.dev.paulovieira.restfulapispring.dto.factory.*;
 import br.dev.paulovieira.restfulapispring.model.*;
 import br.dev.paulovieira.restfulapispring.model.factory.*;
 import br.dev.paulovieira.restfulapispring.service.impl.*;
@@ -13,13 +14,13 @@ import org.springframework.http.*;
 import java.net.*;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.*;
 
 
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class PersonControllerTest {
 
     @InjectMocks
@@ -39,8 +40,8 @@ class PersonControllerTest {
 
     @Test
     @DisplayName("Find person by id")
-    void shouldReturnAPersonById() {
-        when(personService.findById(anyLong())).thenReturn(person);
+    void testFindById() {
+        when(personService.findById(anyLong())).thenReturn(personDto);
         when(mapper.personToDto(person)).thenReturn(personDto);
 
         var response = personController.findById(1L);
@@ -50,10 +51,10 @@ class PersonControllerTest {
     }
 
     @Test
-    @DisplayName("Find all persons")
-    void shouldReturnAllPersons() {
+    @DisplayName("Find all people")
+    void testFindAll() {
         var pageable = PageRequest.of(0, 10, Sort.Direction.ASC, "id");
-        var page = new PageImpl<>(List.of(person));
+        var page = new PageImpl<>(List.of(personDto));
         when(personService.findAll(any(Pageable.class))).thenReturn(page);
         when(mapper.personToDto(person)).thenReturn(personDto);
 
@@ -61,16 +62,16 @@ class PersonControllerTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(1, response.getBody().getContent().size());
-        assertEquals(personDto.firstName(), response.getBody().getContent().get(0).firstName());
-        assertEquals(personDto.lastName(), response.getBody().getContent().get(0).lastName());
-        assertEquals(personDto.address(), response.getBody().getContent().get(0).address());
-        assertEquals(personDto.gender(), response.getBody().getContent().get(0).gender());
+        assertEquals(personDto.getFirstName(), response.getBody().getContent().get(0).getFirstName());
+        assertEquals(personDto.getLastName(), response.getBody().getContent().get(0).getLastName());
+        assertEquals(personDto.getAddress(), response.getBody().getContent().get(0).getAddress());
+        assertEquals(personDto.getGender(), response.getBody().getContent().get(0).getGender());
     }
 
     @Test
     @DisplayName("Create a person")
-    void shouldCreateAPerson() throws URISyntaxException {
-        when(personService.save(personDto)).thenReturn(person);
+    void testSave() throws URISyntaxException {
+        when(personService.save(personDto)).thenReturn(personDto);
         when(mapper.personToDto(person)).thenReturn(personDto);
 
         var response = personController.save(personDto);
@@ -81,9 +82,9 @@ class PersonControllerTest {
 
     @Test
     @DisplayName("Update a person")
-    void shouldUpdateAPerson() {
-        when(personService.findById(anyLong())).thenReturn(person);
-        when(personService.update(any(PersonDto.class))).thenReturn(person);
+    void testUpdate() {
+        when(personService.findById(anyLong())).thenReturn(personDto);
+        when(personService.update(any(PersonDto.class))).thenReturn(personDto);
         when(mapper.personToDto(person)).thenReturn(personDto);
 
         var response = personController.update(1L, personDto);
@@ -93,7 +94,7 @@ class PersonControllerTest {
 
     @Test
     @DisplayName("Delete a person")
-    void shouldDeleteAPerson() {
+    void testDelete() {
         doNothing().when(personService).deleteById(anyLong());
 
         var response = personController.delete(1L);
@@ -105,7 +106,7 @@ class PersonControllerTest {
     private void startPerson() {
         person = PersonFactory.create(1L, "Paulo", "Vieira",
                 "Rua Spring Boot", "Male");
-        personDto = new PersonDto(person.getId(), person.getFirstName(),
+        personDto = PersonDtoFactory.create(person.getId(), person.getFirstName(),
                 person.getLastName(), person.getAddress(), person.getGender());
     }
 }

--- a/src/test/java/br/dev/paulovieira/restfulapispring/dto/PersonDtoTest.java
+++ b/src/test/java/br/dev/paulovieira/restfulapispring/dto/PersonDtoTest.java
@@ -1,5 +1,6 @@
 package br.dev.paulovieira.restfulapispring.dto;
 
+import br.dev.paulovieira.restfulapispring.dto.factory.*;
 import br.dev.paulovieira.restfulapispring.model.*;
 import br.dev.paulovieira.restfulapispring.model.factory.*;
 import br.dev.paulovieira.restfulapispring.util.impl.*;
@@ -31,19 +32,20 @@ class PersonDtoTest {
         var person = mapper.dtoToPerson(personDto);
 
         assertNotNull(person);
-        assertEquals(personDto.firstName(), person.getFirstName());
-        assertEquals(personDto.lastName(), person.getLastName());
-        assertEquals(personDto.address(), person.getAddress());
-        assertEquals(personDto.gender(), person.getGender());
+        assertEquals(personDto.getId(), person.getId());
+        assertEquals(personDto.getFirstName(), person.getFirstName());
+        assertEquals(personDto.getLastName(), person.getLastName());
+        assertEquals(personDto.getAddress(), person.getAddress());
+        assertEquals(personDto.getGender(), person.getGender());
     }
 
     @Test
     void shouldReturnAListOfPerson() {
-        var personsDto = getListOfPersonsDto();
-        var persons = mapper.dtoToPerson(personsDto);
+        var personsDto = getListOfPeopleDto();
+        var people = mapper.dtoToPerson(personsDto);
 
-        assertNotNull(persons);
-        assertEquals(personsDto.size(), persons.size());
+        assertNotNull(people);
+        assertEquals(personsDto.size(), people.size());
     }
 
     @Test
@@ -51,19 +53,20 @@ class PersonDtoTest {
         var personDto = mapper.personToDto(person);
 
         assertNotNull(personDto);
-        assertEquals(person.getFirstName(), personDto.firstName());
-        assertEquals(person.getLastName(), personDto.lastName());
-        assertEquals(person.getAddress(), personDto.address());
-        assertEquals(person.getGender(), personDto.gender());
+        assertEquals(person.getId(), personDto.getId());
+        assertEquals(person.getFirstName(), personDto.getFirstName());
+        assertEquals(person.getLastName(), personDto.getLastName());
+        assertEquals(person.getAddress(), personDto.getAddress());
+        assertEquals(person.getGender(), personDto.getGender());
     }
 
     @Test
     void shouldReturnAListOfPersonDto() {
-        var persons = getListOfPersons();
-        var personsDto = mapper.personToDto(persons);
+        var people = getListOfPeople();
+        var personsDto = mapper.personToDto(people);
 
         assertNotNull(personsDto);
-        assertEquals(persons.size(), personsDto.size());
+        assertEquals(people.size(), personsDto.size());
     }
 
     private void startPerson() {
@@ -76,7 +79,7 @@ class PersonDtoTest {
         );
     }
     private void startPersonDto() {
-        personDto = new PersonDto(
+        personDto = PersonDtoFactory.create(
                 1L,
                 "John",
                 "Doe",
@@ -85,19 +88,19 @@ class PersonDtoTest {
         );
     }
 
-    private List<Person> getListOfPersons() {
-        var persons = new ArrayList<Person>();
+    private List<Person> getListOfPeople() {
+        var people = new ArrayList<Person>();
 
-        persons.add(person);
+        people.add(person);
 
-        return persons;
+        return people;
     }
 
-    private List<PersonDto> getListOfPersonsDto() {
-        var persons = new ArrayList<PersonDto>();
+    private List<PersonDto> getListOfPeopleDto() {
+        var people = new ArrayList<PersonDto>();
 
-        persons.add(personDto);
+        people.add(personDto);
 
-        return persons;
+        return people;
     }
 }


### PR DESCRIPTION
**Detalhes de Implementação**

- Adicionado a Flyway Migrations
- Content Negotiation
- Testes Unitários refeitos
- API agora atende os padrões HATEOAS

Foi necessário refazer o DTO para trabalhar com HATEOAS, o Record não aceita extender de `RepresentationModel<T extends RepresentationModel<? extends T>>`, por isso tive que refatorar para uma classe.

O método update estava funcionando de forma incorreta, a lógica estava no Controller ao invés de estar na camada de Serviço, isso foi refatorado.